### PR TITLE
Allow up to 4 logos in homepage services cards

### DIFF
--- a/assets/scss/components/_services-list.scss
+++ b/assets/scss/components/_services-list.scss
@@ -57,7 +57,7 @@
   }
 
   a {
-    padding: 0 50px 110px;
+    padding: 0 50px 160px;
     height: 100%;
     display: block;
     color: $color-primary;

--- a/assets/scss/components/_sliding-button.scss
+++ b/assets/scss/components/_sliding-button.scss
@@ -7,6 +7,7 @@
   right: 0;
   bottom: 0;
   display: flex;
+  flex-wrap: wrap;
   background: #fff;
   overflow: hidden;
 
@@ -24,9 +25,15 @@
     padding: 0 20px;
     width: 50%;
     border-right: solid 1px $color-border;
+    border-bottom: solid 1px $color-border;
 
-    &:last-of-type {
+    &:nth-of-type(even) {
       border-right: none;
+    }
+
+    &:last-of-type,
+    &:nth-last-of-type(2) {
+      border-bottom: none;
     }
   }
 }
@@ -57,6 +64,18 @@
 
   .sliding-button__content {
     border-top: solid 1px transparent;
+  }
+}
+
+.sliding-button--large {
+  height: 160px;
+
+  &:before {
+    height: 160px;
+  }
+
+  .sliding-button__content {
+    height: 160px;
   }
 }
 

--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -141,7 +141,11 @@
                                     <h4>Conception sur-mesure d'infrastructures</h4>
                                     <p>Étude des contraintes d'exploitation de vos projets (nous n'hésitons pas à mettre le nez dans l'applicatif, nous prenons le temps de comprendre votre métier et vos objectifs) et conception d'infrastructures sur-mesure. </p>
                                     <p>Kubernetes, Openstack ou bare metal.</p>
-                                    <span class="sliding-button">
+                                    <span class="sliding-button sliding-button--large sliding-button--replaced">
+                                        <img src="{{ asset('build/images/services/ovh-cloud.svg') }}" alt="OVH Cloud">
+                                        <img src="{{ asset('build/images/services/scaleway.svg') }}" alt="Scaleway">
+                                        <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
+                                        <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
                                         <span class="sliding-button__content">
                                             <i class="icon icon--arrow" aria-hidden="true"></i>
                                             Découvrir les services
@@ -154,11 +158,11 @@
                                     <img src="{{ asset('build/images/services/cloud.svg') }}" alt="">
                                     <h4>Expertise Kubernetes</h4>
                                     <p>Conception et mise en oeuvre avec vos équipes <strong>(c'est important;))</strong> de cluster Kubernetes. Stratégies de déploiement, supervision... </p>
-                                    <span class="sliding-button sliding-button--replaced">
-                                        <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
-                                        <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
+                                    <span class="sliding-button sliding-button--large sliding-button--replaced">
                                         <img src="{{ asset('build/images/services/ovh-cloud.svg') }}" alt="OVH Cloud">
                                         <img src="{{ asset('build/images/services/scaleway.svg') }}" alt="Scaleway">
+                                        <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
+                                        <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
                                         <span class="sliding-button__content">
                                             <i class="icon icon--arrow" aria-hidden="true"></i>
                                             Découvrir les services

--- a/templates/site/services.html.twig
+++ b/templates/site/services.html.twig
@@ -87,18 +87,18 @@
         </section>
         <div class="page-services__images">
             <span>
-                <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
-            </span>
-            <span>
-                <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
-            </span>
-        </div>
-        <div class="page-services__images">
-            <span>
                 <img src="{{ asset('build/images/services/ovh-cloud.svg') }}" alt="AWS">
             </span>
             <span>
                 <img src="{{ asset('build/images/services/scaleway.svg') }}" alt="Google Cloud">
+            </span>
+        </div>
+        <div class="page-services__images">
+            <span>
+                <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
+            </span>
+            <span>
+                <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
             </span>
         </div>
         <section class="page-services__content" id="pilotage_infrastructures">
@@ -133,18 +133,18 @@
         </section>
         <div class="page-services__images">
             <span>
-                <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
-            </span>
-            <span>
-                <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
-            </span>
-        </div>
-        <div class="page-services__images">
-            <span>
                 <img src="{{ asset('build/images/services/ovh-cloud.svg') }}" alt="AWS">
             </span>
             <span>
                 <img src="{{ asset('build/images/services/scaleway.svg') }}" alt="Google Cloud">
+            </span>
+        </div>
+        <div class="page-services__images">
+            <span>
+                <img src="{{ asset('build/images/services/aws.svg') }}" alt="AWS">
+            </span>
+            <span>
+                <img src="{{ asset('build/images/services/google-cloud.svg') }}" alt="Google Cloud">
             </span>
         </div>
     </div>


### PR DESCRIPTION
@gfaivre contrairement à ce que je t'ai dit ici https://github.com/rix-fr/rix/issues/24 ça me coûte pas plus cher de mettre les 4 technos et de modifier un peu de CSS que de mettre 3 logos en ligne et de devoir là aussi modifier l'inté. Je te propose ça : 

| 4 logos (hover) | 2 logos (hover) |
| - | - |
| ![Capture d’écran 2022-09-13 à 14 29 33](https://user-images.githubusercontent.com/25897625/189901280-5693b8e4-46bf-4a53-8020-8b826128da05.png) | ![Capture d’écran 2022-09-13 à 14 29 41](https://user-images.githubusercontent.com/25897625/189901287-bebe8a28-3733-4a9e-9a8e-82ed5d26a564.png) |

/!\ Néanmoins attention c'est pas idéal parce que la hauteur de ce machin est fixée en dur donc à chaque modif Sabrina ou moi devrons potentiellement repasser dessus pour ajuster (pas ouf mais pas l'choix avec la maquette)
/!\ Néanmoins attention (bis) on a peut-être sous-estimé l'importance de ce bloc là quand on a fait les maquettes car ces technos sont cachées en responsive et ne sont accessibles que sur la page `Services` dédiée


Fix https://github.com/rix-fr/rix/issues/24