### PR TITLE
[CI] Get rid of matrix for deploy variables

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,22 +13,13 @@ concurrency:
 jobs:
 
   deploy-production:
-    name: ${{ matrix.name }}
+    name: '🚧  Build & deploy 🚀'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     environment:
       name: production
-      url: https://www.rix.fr
-
-    # Expose some Github Workflow variables using a matrix, to be used in next steps:
-    strategy:
-      matrix:
-        include:
-          - name: '🚧  Build & deploy 🚀'
-            WEBSITE_URL: https://www.rix.fr
-            DEPLOY_PATH: /srv/app/website
-            MATOMO_ID: 10
+      url: ${{ vars.WEBSITE_URL }}
 
     steps:
       - name: 'Checkout'
@@ -98,14 +89,14 @@ jobs:
         run: bin/console stenope:build --no-interaction -vv --ansi --ignore-content-not-found
         env:
           APP_ENV: prod
-          ROUTER_DEFAULT_URI: ${{ matrix.WEBSITE_URL }}
+          ROUTER_DEFAULT_URI: ${{ vars.WEBSITE_URL }}
           INCLUDE_SAMPLES: 0
           SHOW_UNPUBLISHED_ARTICLES: 0
-          MATOMO_ID: ${{ matrix.MATOMO_ID }}
+          MATOMO_ID: ${{ vars.MATOMO_ID }}
 
       - name: '🚀 Deploy'
         run: |
-          rsync build/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:${{ matrix.DEPLOY_PATH }} \
+          rsync build/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:${{ vars.DEPLOY_PATH }} \
             --human-readable \
             --compress \
             --archive \


### PR DESCRIPTION
See https://github.blog/changelog/2023-01-10-github-actions-support-for-configuration-variables-in-workflows/
and https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows

## TODO (before merge)

Set these vars in the repo config (https://github.com/rix-fr/rix/settings/variables/actions):

- `WEBSITE_URL=https://www.rix.fr`
- `DEPLOY_PATH=/srv/app/website`
- `MATOMO_ID=10`